### PR TITLE
Bruke redis for distribuert caching

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ jobs:
     #########################
     ### DEVELOPERS: Insert your feature branch name below (in addition to master) if you want to deploy it to dev
     #########################
-    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bruke-redis-for-distribuert-caching'
+    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/test'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ jobs:
     #########################
     ### DEVELOPERS: Insert your feature branch name below (in addition to master) if you want to deploy it to dev
     #########################
-    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/test'
+    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bruke-redis-for-distribuert-caching'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1

--- a/nais/dev.yaml
+++ b/nais/dev.yaml
@@ -27,5 +27,7 @@ spec:
   env:
     - name: SPRING_PROFILES_ACTIVE
       value: dev
+    - name: REDIS_HOST
+      value: altinn-rettigheter-proxy-redis.default.svc.nais.local
   webproxy: true
 

--- a/nais/dev.yaml
+++ b/nais/dev.yaml
@@ -29,5 +29,7 @@ spec:
       value: dev
     - name: REDIS_HOST
       value: altinn-rettigheter-proxy-redis.default.svc.nais.local
+  prometheus:
+    enabled: true
+    path: /altinn-rettigheter-proxy/internal/actuator/prometheus
   webproxy: true
-

--- a/nais/prod.yaml
+++ b/nais/prod.yaml
@@ -27,4 +27,6 @@ spec:
   env:
     - name: SPRING_PROFILES_ACTIVE
       value: prod
+    - name: REDIS_HOST
+      value: altinn-rettigheter-proxy-redis.default.svc.nais.local
   webproxy: true

--- a/nais/prod.yaml
+++ b/nais/prod.yaml
@@ -29,4 +29,7 @@ spec:
       value: prod
     - name: REDIS_HOST
       value: altinn-rettigheter-proxy-redis.default.svc.nais.local
+  prometheus:
+    enabled: true
+    path: /altinn-rettigheter-proxy/internal/actuator/prometheus
   webproxy: true

--- a/nais/redis.yaml
+++ b/nais/redis.yaml
@@ -1,0 +1,24 @@
+apiVersion: "nais.io/v1alpha1"
+kind: "Application"
+metadata:
+  labels:
+    team: arbeidsgiver
+  name: altinn-rettigheter-proxy-redis
+  namespace: default
+spec:
+  image: navikt/secure-redis:5.0.3-alpine-2
+  port: 6379
+  replicas:
+    min: 1
+    max: 1
+  resources:
+    limits:
+      cpu: 250m
+      memory: 256Mi
+    requests:
+      cpu: 250m
+      memory: 256Mi
+  service:
+    port: 6379
+  vault:
+    enabled: true

--- a/nais/redisexporter.yaml
+++ b/nais/redisexporter.yaml
@@ -1,0 +1,27 @@
+apiVersion: "nais.io/v1alpha1"
+kind: "Application"
+metadata:
+  labels:
+    team: arbeidsgiver
+  name: altinn-rettigheter-proxy-redisexporter
+  namespace: default
+spec:
+  image: navikt/secure-redisexporter:v0.29.0-alpine-3
+  port: 9121
+  prometheus:
+    enabled: true
+  replicas:
+    min: 1
+    max: 1
+  resources:
+    limits:
+      cpu: 100m
+      memory: 100Mi
+    requests:
+      cpu: 100m
+      memory: 100Mi
+  vault:
+    enabled: true
+  env:
+    - name: REDIS_ADDR
+      value: altinn-rettigheter-proxy-redis.default.svc.nais.local:6379

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,11 @@
             <artifactId>spring-boot-configuration-processor</artifactId>
             <optional>true</optional>
         </dependency>
+        <!-- Redis cache -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-redis</artifactId>
+        </dependency>
 
         <!-- OIDC Support -->
         <dependency>
@@ -77,7 +82,6 @@
         </dependency>
 
         <!-- Logging -->
-        <!-- JSON-logging -->
         <dependency>
             <groupId>net.logstash.logback</groupId>
             <artifactId>logstash-logback-encoder</artifactId>

--- a/src/main/kotlin/no/nav/arbeidsgiver/altinnrettigheter/proxy/config/CachingConfig.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/altinnrettigheter/proxy/config/CachingConfig.kt
@@ -9,7 +9,7 @@ import org.springframework.context.annotation.Configuration
 import java.util.concurrent.TimeUnit
 
 
-@Configuration
+//@Configuration
 class CachingConfig {
 
     @Bean

--- a/src/main/kotlin/no/nav/arbeidsgiver/altinnrettigheter/proxy/controller/AltinnrettigheterProxyController.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/altinnrettigheter/proxy/controller/AltinnrettigheterProxyController.kt
@@ -2,21 +2,19 @@ package no.nav.arbeidsgiver.altinnrettigheter.proxy.controller
 
 import no.nav.arbeidsgiver.altinnrettigheter.proxy.model.AltinnOrganisasjon
 import no.nav.arbeidsgiver.altinnrettigheter.proxy.model.Fnr
-import no.nav.arbeidsgiver.altinnrettigheter.proxy.service.AltinnrettigheterProxyService
+import no.nav.arbeidsgiver.altinnrettigheter.proxy.service.AltinnrettigheterService
 import no.nav.arbeidsgiver.altinnrettigheter.proxy.tilgangskontroll.TilgangskontrollService
 import no.nav.security.oidc.api.Protected
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestParam
-import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.server.ResponseStatusException
-import java.lang.RuntimeException
 
 @Protected
 @RestController
-class AltinnrettigheterProxyController(val altinnrettigheterProxyService: AltinnrettigheterProxyService, var tilgangskotrollService: TilgangskontrollService) {
+class AltinnrettigheterProxyController(val altinnrettigheterService: AltinnrettigheterService, var tilgangskotrollService: TilgangskontrollService) {
 
     private val logger = LoggerFactory.getLogger(javaClass)
 
@@ -33,7 +31,7 @@ class AltinnrettigheterProxyController(val altinnrettigheterProxyService: Altinn
         val fnr = tilgangskotrollService.hentInnloggetBruker().fnr
 
         if (Fnr(subject) == fnr) {
-            return altinnrettigheterProxyService.hentOrganisasjoner(query)
+            return altinnrettigheterService.hentOrganisasjoner(query)
         } else {
             throw ResponseStatusException(
                     HttpStatus.FORBIDDEN, "Du har ikke rettigheter til denne")

--- a/src/main/kotlin/no/nav/arbeidsgiver/altinnrettigheter/proxy/controller/AltinnrettigheterProxyController.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/altinnrettigheter/proxy/controller/AltinnrettigheterProxyController.kt
@@ -3,6 +3,7 @@ package no.nav.arbeidsgiver.altinnrettigheter.proxy.controller
 import no.nav.arbeidsgiver.altinnrettigheter.proxy.model.AltinnOrganisasjon
 import no.nav.arbeidsgiver.altinnrettigheter.proxy.model.Fnr
 import no.nav.arbeidsgiver.altinnrettigheter.proxy.service.AltinnrettigheterProxyService
+import no.nav.arbeidsgiver.altinnrettigheter.proxy.service.AltinnrettigheterService
 import no.nav.arbeidsgiver.altinnrettigheter.proxy.tilgangskontroll.TilgangskontrollService
 import no.nav.security.oidc.api.Protected
 import org.slf4j.LoggerFactory
@@ -14,7 +15,7 @@ import org.springframework.web.server.ResponseStatusException
 
 @Protected
 @RestController
-class AltinnrettigheterProxyController(val altinnrettigheterProxyService: AltinnrettigheterProxyService, var tilgangskotrollService: TilgangskontrollService) {
+class AltinnrettigheterProxyController(val altinnrettigheterService: AltinnrettigheterService, var tilgangskotrollService: TilgangskontrollService) {
 
     private val logger = LoggerFactory.getLogger(javaClass)
 
@@ -30,7 +31,7 @@ class AltinnrettigheterProxyController(val altinnrettigheterProxyService: Altinn
         val fnr = tilgangskotrollService.hentInnloggetBruker().fnr
 
         if (Fnr(subject) == fnr) {
-            return altinnrettigheterProxyService.hentOrganisasjoner(fnr, serviceCode, serviceEdition)
+            return altinnrettigheterService.hentOrganisasjoner(fnr, serviceCode, serviceEdition)
         } else {
             throw ResponseStatusException(
                     HttpStatus.FORBIDDEN, "Du har ikke rettigheter til denne")

--- a/src/main/kotlin/no/nav/arbeidsgiver/altinnrettigheter/proxy/model/AltinnOrganisasjon.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/altinnrettigheter/proxy/model/AltinnOrganisasjon.kt
@@ -1,6 +1,7 @@
 package no.nav.arbeidsgiver.altinnrettigheter.proxy.model
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import java.io.Serializable
 
 data class AltinnOrganisasjon(
         @JsonProperty("Name")
@@ -15,15 +16,4 @@ data class AltinnOrganisasjon(
         val organizationForm: String,
         @JsonProperty("Status")
         val status: String
-)
-
-data class AltinnRolle(
-        @JsonProperty("RoleType")
-        private var type: String,
-        @JsonProperty("RoleDefinitionId")
-        private val definitionId: String,
-        @JsonProperty("RoleName")
-        private val name: String,
-        @JsonProperty("RoleDescription")
-        private val description: String? = null
-)
+) : Serializable

--- a/src/main/kotlin/no/nav/arbeidsgiver/altinnrettigheter/proxy/service/AltinnrettigheterProxyService.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/altinnrettigheter/proxy/service/AltinnrettigheterProxyService.kt
@@ -13,7 +13,11 @@ class AltinnrettigheterProxyService(val altinnClient: AltinnClient) {
     private val logger = LoggerFactory.getLogger(javaClass)
 
     @Cacheable(REPORTEES_CACHE)
-    fun hentOrganisasjoner(query: Map<String, String>): List<AltinnOrganisasjon> {
+    fun hentOrganisasjonerCached(query: Map<String, String>): List<AltinnOrganisasjon> {
+        return hentOrganisasjonerIAltinn(query)
+    }
+
+    fun hentOrganisasjonerIAltinn(query: Map<String, String>): List<AltinnOrganisasjon> {
         logger.info("Kall til Altinn")
         return altinnClient.hentOrganisasjoner(query)
     }

--- a/src/main/kotlin/no/nav/arbeidsgiver/altinnrettigheter/proxy/service/AltinnrettigheterProxyService.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/altinnrettigheter/proxy/service/AltinnrettigheterProxyService.kt
@@ -13,7 +13,11 @@ class AltinnrettigheterProxyService(val altinnClient: AltinnClient) {
     private val logger = LoggerFactory.getLogger(javaClass)
 
     @Cacheable("reportees")
-    fun hentOrganisasjoner(fnr: Fnr, serviceCode: String, serviceEdition: String): List<AltinnOrganisasjon> {
+    fun hentOrganisasjonerCached(fnr: Fnr, serviceCode: String, serviceEdition: String): List<AltinnOrganisasjon> {
+        return hentOrganisasjonerIAltinn(fnr, serviceCode, serviceEdition)
+    }
+
+    fun hentOrganisasjonerIAltinn(fnr: Fnr, serviceCode: String, serviceEdition: String): List<AltinnOrganisasjon> {
         logger.info("Kall til Altinn")
         return altinnClient.hentOrgnumreDerBrukerHarEnkeltrettighetTilIAWeb(fnr, serviceCode, serviceEdition)
     }

--- a/src/main/kotlin/no/nav/arbeidsgiver/altinnrettigheter/proxy/service/AltinnrettigheterService.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/altinnrettigheter/proxy/service/AltinnrettigheterService.kt
@@ -1,0 +1,22 @@
+package no.nav.arbeidsgiver.altinnrettigheter.proxy.service
+
+import no.nav.arbeidsgiver.altinnrettigheter.proxy.model.AltinnOrganisasjon
+import no.nav.arbeidsgiver.altinnrettigheter.proxy.model.Fnr
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+
+@Service
+class AltinnrettigheterService(val proxyService: AltinnrettigheterProxyService) {
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    fun hentOrganisasjoner(fnr: Fnr, serviceCode: String, serviceEdition: String): List<AltinnOrganisasjon> {
+        return try {
+            proxyService.hentOrganisasjonerCached(fnr, serviceCode, serviceEdition)
+        } catch (e: Exception) {
+            logger.warn("Fallback etter feil mot Redis cache, pga feil ${e.message}")
+            proxyService.hentOrganisasjonerIAltinn(fnr, serviceCode, serviceEdition)
+        }
+    }
+
+}

--- a/src/main/kotlin/no/nav/arbeidsgiver/altinnrettigheter/proxy/service/AltinnrettigheterService.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/altinnrettigheter/proxy/service/AltinnrettigheterService.kt
@@ -1,7 +1,6 @@
 package no.nav.arbeidsgiver.altinnrettigheter.proxy.service
 
 import no.nav.arbeidsgiver.altinnrettigheter.proxy.model.AltinnOrganisasjon
-import no.nav.arbeidsgiver.altinnrettigheter.proxy.model.Fnr
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 
@@ -10,12 +9,12 @@ class AltinnrettigheterService(val proxyService: AltinnrettigheterProxyService) 
 
     private val logger = LoggerFactory.getLogger(javaClass)
 
-    fun hentOrganisasjoner(fnr: Fnr, serviceCode: String, serviceEdition: String): List<AltinnOrganisasjon> {
+    fun hentOrganisasjoner(query: Map<String, String>): List<AltinnOrganisasjon> {
         return try {
-            proxyService.hentOrganisasjonerCached(fnr, serviceCode, serviceEdition)
+            proxyService.hentOrganisasjonerCached(query)
         } catch (e: Exception) {
             logger.warn("Fallback etter feil mot Redis cache, pga feil ${e.message}")
-            proxyService.hentOrganisasjonerIAltinn(fnr, serviceCode, serviceEdition)
+            proxyService.hentOrganisasjonerIAltinn(query)
         }
     }
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -59,7 +59,7 @@ spring:
     timeout: 500
   cache:
     redis:
-      time-to-live: 60000 # 1 min i millis
+      time-to-live: 300000 # 5 min i millis
 
 altinn:
   url: "https://api-gw-q1.adeo.no/"

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -16,6 +16,15 @@ spring:
 spring:
   profiles: local
 
+  redis:
+    host: localhost
+    port: 6379
+    password: foobared # default passord lokalt i /usr/local/etc/redis.conf
+    timeout: 500
+  cache:
+    redis:
+      time-to-live: 30000 # 30 sek i millis
+
 server:
   port: 9090
 
@@ -46,6 +55,14 @@ no.nav.security.oidc:
 
 spring:
   profiles: dev
+  redis:
+    host: ${REDIS_HOST}
+    port: 6379
+    password: ${REDIS_PASSWORD}
+    timeout: 500
+  cache:
+    redis:
+      time-to-live: 30000 # 30 sek i millis
 
 altinn:
   url: "https://api-gw-q1.adeo.no/"
@@ -64,6 +81,14 @@ no.nav.security.oidc:
 
 spring:
   profiles: prod
+  redis:
+    host: ${REDIS_HOST}
+    port: 6379
+    password: ${REDIS_PASSWORD}
+    timeout: 500
+  cache:
+    redis:
+      time-to-live: 30000 # 30 sek i millis
 
 altinn:
   url: "https://api-gw.adeo.no/"

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -59,7 +59,7 @@ spring:
     timeout: 500
   cache:
     redis:
-      time-to-live: 30000 # 30 sek i millis
+      time-to-live: 60000 # 1 min i millis
 
 altinn:
   url: "https://api-gw-q1.adeo.no/"
@@ -82,7 +82,7 @@ spring:
     timeout: 500
   cache:
     redis:
-      time-to-live: 30000 # 30 sek i millis
+      time-to-live: 300000 # 5 min i millis
 
 altinn:
   url: "https://api-gw.adeo.no/"


### PR DESCRIPTION
Denne PR inneholder
 - konfig til å bruke Redis i dev og prod (secure-redis image)
 - konfig for redis-exporter (metrics på https://grafana.adeo.no/d/L-Ktprrmz)
 - fallback mekaniske slik at proxy fungerer fortsatt selv om Redis ikke er tilgjengelig eller feilkonfigurert 