### PR TITLE
Handtere 502 bad gateway error

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ jobs:
     #########################
     ### DEVELOPERS: Insert your feature branch name below (in addition to master) if you want to deploy it to dev
     #########################
-    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/handtere-502-bad-gateway-error'
+    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/test'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ jobs:
     #########################
     ### DEVELOPERS: Insert your feature branch name below (in addition to master) if you want to deploy it to dev
     #########################
-    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/test'
+    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/handtere-502-bad-gateway-error'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1

--- a/src/main/kotlin/no/nav/arbeidsgiver/altinnrettigheter/proxy/RestResponseEntityExceptionHandler.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/altinnrettigheter/proxy/RestResponseEntityExceptionHandler.kt
@@ -1,7 +1,7 @@
 package no.nav.arbeidsgiver.altinnrettigheter.proxy
 
 import no.nav.arbeidsgiver.altinnrettigheter.proxy.altinn.AltinnException
-import no.nav.arbeidsgiver.altinnrettigheter.proxy.altinn.ProxyClientErrorException
+import no.nav.arbeidsgiver.altinnrettigheter.proxy.altinn.ProxyHttpStatusCodeException
 import no.nav.arbeidsgiver.altinnrettigheter.proxy.tilgangskontroll.TilgangskontrollException
 import no.nav.security.spring.oidc.validation.interceptor.OIDCUnauthorizedException
 import org.slf4j.LoggerFactory
@@ -16,7 +16,6 @@ import org.springframework.web.server.ResponseStatusException
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler
 import java.nio.file.AccessDeniedException
 import java.util.*
-import java.util.stream.Collectors.toMap
 
 
 @ControllerAdvice
@@ -41,13 +40,13 @@ class RestResponseEntityExceptionHandler : ResponseEntityExceptionHandler() {
         return getResponseEntity(e, "Internal error", HttpStatus.INTERNAL_SERVER_ERROR)
     }
 
-    @ExceptionHandler(value = [ProxyClientErrorException::class])
+    @ExceptionHandler(value = [ProxyHttpStatusCodeException::class])
     @ResponseBody
-    protected fun handleAltinnHttpClientErrorException(
-            e: ProxyClientErrorException,
+    protected fun handleProxyHttpStatusCodeException(
+            e: ProxyHttpStatusCodeException,
             webRequest: WebRequest?
     ): ResponseEntity<Any> {
-        Companion.logger.warn("Klient feil ved Altinn integrasjon, " +
+        Companion.logger.warn("Feil ved Altinn integrasjon, " +
                 "med status '${e.httpStatus}' " +
                 ", statusText '${e.statusText}'" +
                 " og responseBody '${e.responseBodyAsString}'",

--- a/src/main/kotlin/no/nav/arbeidsgiver/altinnrettigheter/proxy/altinn/AltinnClient.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/altinnrettigheter/proxy/altinn/AltinnClient.kt
@@ -10,7 +10,7 @@ import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Component
-import org.springframework.web.client.HttpClientErrorException
+import org.springframework.web.client.HttpStatusCodeException
 import org.springframework.web.client.RestClientException
 import org.springframework.web.client.RestTemplate
 import org.springframework.web.util.UriComponentsBuilder
@@ -46,9 +46,9 @@ class AltinnClient(restTemplateBuilder: RestTemplateBuilder) {
                 throw RuntimeException(message)
             }
             respons.body!!
-        } catch (exception: HttpClientErrorException) {
+        } catch (exception: HttpStatusCodeException) {
             if (exception.statusCode.isError) {
-                throw ProxyClientErrorException(
+                throw ProxyHttpStatusCodeException(
                         exception.statusCode,
                         exception.statusText,
                         exception.responseBodyAsString,

--- a/src/main/kotlin/no/nav/arbeidsgiver/altinnrettigheter/proxy/altinn/ProxyHttpStatusCodeException.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/altinnrettigheter/proxy/altinn/ProxyHttpStatusCodeException.kt
@@ -1,11 +1,11 @@
 package no.nav.arbeidsgiver.altinnrettigheter.proxy.altinn
 
 import org.springframework.http.HttpStatus
-import org.springframework.web.client.HttpClientErrorException
+import org.springframework.web.client.HttpStatusCodeException
 
-class ProxyClientErrorException(
+class ProxyHttpStatusCodeException(
         var httpStatus: HttpStatus,
         var statusText: String,
         var responseBodyAsString: String,
-        exception: HttpClientErrorException
+        exception: HttpStatusCodeException
 ) : RuntimeException(exception)

--- a/src/main/kotlin/no/nav/arbeidsgiver/altinnrettigheter/proxy/service/AltinnrettigheterService.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/altinnrettigheter/proxy/service/AltinnrettigheterService.kt
@@ -1,7 +1,7 @@
 package no.nav.arbeidsgiver.altinnrettigheter.proxy.service
 
 import no.nav.arbeidsgiver.altinnrettigheter.proxy.altinn.AltinnException
-import no.nav.arbeidsgiver.altinnrettigheter.proxy.altinn.ProxyClientErrorException
+import no.nav.arbeidsgiver.altinnrettigheter.proxy.altinn.ProxyHttpStatusCodeException
 import no.nav.arbeidsgiver.altinnrettigheter.proxy.model.AltinnOrganisasjon
 import no.nav.arbeidsgiver.altinnrettigheter.proxy.model.Fnr
 import org.slf4j.LoggerFactory
@@ -17,7 +17,7 @@ class AltinnrettigheterService(val proxyService: AltinnrettigheterProxyService) 
             proxyService.hentOrganisasjonerCached(query, fnr)
         } catch (e: Exception) {
             when (e) {
-                is ProxyClientErrorException,
+                is ProxyHttpStatusCodeException,
                 is AltinnException -> throw e
                 else -> {
                     logger.warn("Fallback etter feil mot Redis cache, pga feil ${e.message}")

--- a/src/test/kotlin/no/nav/arbeidsgiver/altinnrettigheter/proxy/altinn/AltinnKlientRestTemplateTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/altinnrettigheter/proxy/altinn/AltinnKlientRestTemplateTest.kt
@@ -30,7 +30,7 @@ class AltinnKlientRestTemplateTest {
 
 
     @Test
-    fun altinnKlient_hentOrganisasjoner_sender_kall_till_Altinn_med_riktige_parametre() {
+    fun altinnKlient_hentOrganisasjoner_sender_kall_til_Altinn_med_riktige_parametre() {
 
         server.expect(
                 ExpectedCount.once(),


### PR DESCRIPTION
AltinnKlient catcher `HttpStatusCodeException` i stedet av `HttpClientErrorException` slikk at både 4xx og 5xx retur koder blir fanget og ikke provoserer Error lenger i proxy-en