### PR TITLE
Legg til nytt endepunkt for proxy klient bibliotek

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ jobs:
     #########################
     ### DEVELOPERS: Insert your feature branch name below (in addition to master) if you want to deploy it to dev
     #########################
-    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/legg-til-nytt-endepunkt-for-proxy-klient-bibliotek'
+    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/test'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ jobs:
     #########################
     ### DEVELOPERS: Insert your feature branch name below (in addition to master) if you want to deploy it to dev
     #########################
-    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/test'
+    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/legg-til-nytt-endepunkt-for-proxy-klient-bibliotek'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1

--- a/src/main/kotlin/no/nav/arbeidsgiver/altinnrettigheter/proxy/controller/AltinnrettigheterProxyController.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/altinnrettigheter/proxy/controller/AltinnrettigheterProxyController.kt
@@ -19,12 +19,13 @@ class AltinnrettigheterProxyController(val altinnrettigheterService: Altinnretti
 
     @GetMapping(value = ["organisasjoner"])
     fun proxyOrganisasjonerNY(
-            @RequestParam query: Map<String, String>
+            @RequestParam serviceCode: String, @RequestParam serviceEdition: String
     ): List<AltinnOrganisasjon> {
         return proxyOrganisasjoner(
-                leggTilParameter(
-                        query, "ForceEIAuthentication",
-                        ""
+                mapOf(
+                        "ForceEIAuthentication" to "",
+                        "serviceCode" to serviceCode,
+                        "serviceEdition" to serviceEdition
                 )
         )
     }
@@ -43,12 +44,6 @@ class AltinnrettigheterProxyController(val altinnrettigheterService: Altinnretti
         )
     }
 
-
-    private fun leggTilParameter(query: Map<String, String>, key: String, value: String): Map<String, String> {
-        val oppdaterbarQuery = query.toMutableMap()
-        oppdaterbarQuery[key] = value
-        return oppdaterbarQuery.toMap()
-    }
 
     private fun validerOgFiltrerQuery(query: Map<String, String>): Map<String, String> {
         validerObligatoriskeParametre(query,"ForceEIAuthentication")

--- a/src/test/kotlin/no/nav/arbeidsgiver/altinnrettigheter/proxy/ApiTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/altinnrettigheter/proxy/ApiTest.kt
@@ -22,6 +22,56 @@ class ApiTest {
 
 
     @Test
+    fun `Endepunkt _organisasjoner_ krever AUTH header med gyldig token`() {
+
+        val response = HttpClient.newBuilder().build().send(
+                HttpRequest.newBuilder()
+                        .uri(
+                                URI.create(
+                                        "http://localhost:$port" +
+                                                "/altinn-rettigheter-proxy/organisasjoner" +
+                                                "?serviceCode=3403" +
+                                                "&serviceEdition=1"
+                                )
+                        )
+                        .header(
+                                HttpHeaders.AUTHORIZATION,
+                                "Bearer " + JwtTokenGenerator.signedJWTAsString("01065500791")
+                        )
+                        .GET()
+                        .build(),
+                BodyHandlers.ofString()
+        )
+
+        Assertions.assertThat(response.statusCode()).isEqualTo(200)
+    }
+
+    @Test
+    fun `Endepunkt _organisasjoner_ trenger gyldig token med fnr, serviceCode og serviceEdition`() {
+
+        val response = HttpClient.newBuilder().build().send(
+                HttpRequest.newBuilder()
+                        .uri(
+                                URI.create(
+                                        "http://localhost:$port" +
+                                                "/altinn-rettigheter-proxy/ekstern/altinn/api/serviceowner/reportees" +
+                                                "?serviceCode=3403"
+                                )
+                        )
+                        .header(
+                                HttpHeaders.AUTHORIZATION,
+                                "Bearer " + JwtTokenGenerator.signedJWTAsString("01065500791")
+                        )
+                        .GET()
+                        .build(),
+                BodyHandlers.ofString()
+        )
+
+        Assertions.assertThat(response.statusCode()).isEqualTo(400)
+        Assertions.assertThat(response.body()).isEqualTo("{\"message\":\"400 BAD_REQUEST \\\"Obligatoriske parametre ble ikke sendt med: [ForceEIAuthentication]\\\"\"}")
+    }
+
+    @Test
     fun `Request med gyldig token og fnr som matcher subject får et svar`() {
 
         val response = HttpClient.newBuilder().build().send(
@@ -31,7 +81,6 @@ class ApiTest {
                                         "http://localhost:$port" +
                                                 "/altinn-rettigheter-proxy/ekstern/altinn/api/serviceowner/reportees" +
                                                 "?ForceEIAuthentication" +
-                                                "&subject=01065500791" +
                                                 "&serviceCode=3403" +
                                                 "&serviceEdition=1"
                                 )

--- a/src/test/kotlin/no/nav/arbeidsgiver/altinnrettigheter/proxy/ApiTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/altinnrettigheter/proxy/ApiTest.kt
@@ -103,7 +103,7 @@ class ApiTest {
      */
 
     @Test
-    fun `Request med gyldig token og fnr som matcher subject får et svar`() {
+    fun `Request med gyldig token får et svar`() {
 
         val response = HttpClient.newBuilder().build().send(
                 HttpRequest.newBuilder()

--- a/src/test/kotlin/no/nav/arbeidsgiver/altinnrettigheter/proxy/altinn/AltinnKlientRestTemplateTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/altinnrettigheter/proxy/altinn/AltinnKlientRestTemplateTest.kt
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.client.RestClientTest
 import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.junit4.SpringRunner
 import org.springframework.test.web.client.ExpectedCount
@@ -43,7 +44,11 @@ class AltinnKlientRestTemplateTest {
                 )
         )
                 .andExpect(method(HttpMethod.GET))
-                .andRespond(withStatus(HttpStatus.OK))
+                .andRespond(
+                        withStatus(HttpStatus.OK)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .body("[]")
+                )
 
         klient.hentOrganisasjoner(
                 mapOf(
@@ -106,7 +111,7 @@ class AltinnKlientRestTemplateTest {
             klient.hentOrganisasjoner(
                     mapOf(
                             "ForceEIAuthentication" to "",
-                            "serviceCode" to "9999",
+                            "serviceCode" to "3403",
                             "serviceEdition" to "1"
                     ),
                     Fnr("01065500791")


### PR DESCRIPTION
Endepunkt `/organisasjoner` med request parametere `serviceCode` og `serviceEdition` (men uten `ForceEIAuthentication`) returnerer samme data som `/ekstern/altinn/api/serviceowner/reportees`. 
Krever autentisering. 