### PR TITLE
Hente ut alle organisasjoner med paginering og filter

### DIFF
--- a/src/main/kotlin/no/nav/arbeidsgiver/altinnrettigheter/proxy/controller/AltinnrettigheterProxyController.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/altinnrettigheter/proxy/controller/AltinnrettigheterProxyController.kt
@@ -1,12 +1,14 @@
 package no.nav.arbeidsgiver.altinnrettigheter.proxy.controller
 
 import no.nav.arbeidsgiver.altinnrettigheter.proxy.model.AltinnOrganisasjon
+import no.nav.arbeidsgiver.altinnrettigheter.proxy.model.Fnr
 import no.nav.arbeidsgiver.altinnrettigheter.proxy.service.AltinnrettigheterService
 import no.nav.arbeidsgiver.altinnrettigheter.proxy.tilgangskontroll.TilgangskontrollService
 import no.nav.metrics.MetricsFactory
 import no.nav.metrics.Timer
 import no.nav.security.oidc.api.Protected
 import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestHeader
@@ -16,23 +18,43 @@ import org.springframework.web.server.ResponseStatusException
 
 @Protected
 @RestController
-class AltinnrettigheterProxyController(val altinnrettigheterService: AltinnrettigheterService, var tilgangskontrollService: TilgangskontrollService) {
+class AltinnrettigheterProxyController(
+        val altinnrettigheterService: AltinnrettigheterService,
+        var tilgangskontrollService: TilgangskontrollService
+) {
 
     private val logger = LoggerFactory.getLogger(javaClass)
 
+    @Value(value = "\${altinn.reportees.pagesize}")
+    lateinit var altinnReporteesPageSize: String
+
+
     @GetMapping(value = ["organisasjoner"])
-    fun proxyOrganisasjonerNY(
+    fun hentOrganisasjoner(
             @RequestHeader(value = "X-Consumer-ID", required = false) consumerId: String?,
-            @RequestParam serviceCode: String, @RequestParam serviceEdition: String
+            @RequestParam serviceCode: String,
+            @RequestParam serviceEdition: String,
+            @RequestParam(value = "inkluderAlle", defaultValue = "false", required = false) inkluderAlle: String
     ): List<AltinnOrganisasjon> {
-        return proxyOrganisasjoner(
-                consumerId,
-                mapOf(
-                        "ForceEIAuthentication" to "",
-                        "serviceCode" to serviceCode,
-                        "serviceEdition" to serviceEdition
-                )
+        logger.info("Mottatt request for organisasjoner innlogget brukeren har rettigheter i. " +
+                "InkluderAlle?: $inkluderAlle ")
+        val responsetidPerKlient: Timer = startResponseTidPerKlient(consumerId)
+        val responsetidAlleKlienter: Timer = startResponseTidAlleKlienter()
+
+        val inkluderAlleBool = "true".equals(inkluderAlle.toLowerCase())
+        val fnr = tilgangskontrollService.hentInnloggetBruker().fnr
+        val organisasjoner =  hentOrganisasjoner(
+                inkluderAlleBool,
+                serviceCode,
+                serviceEdition,
+                fnr
         )
+
+        responsetidPerKlient.stop().report()
+        responsetidAlleKlienter.stop().report()
+        reportKallTilEndepunkt(consumerId)
+
+        return organisasjoner;
     }
 
     @GetMapping(value = ["ekstern/altinn/api/serviceowner/reportees"])
@@ -40,19 +62,12 @@ class AltinnrettigheterProxyController(val altinnrettigheterService: Altinnretti
             @RequestHeader(value = "X-Consumer-ID", required = false) consumerId: String?,
             @RequestParam query: Map<String, String>
     ): List<AltinnOrganisasjon> {
-        logger.info("Mottatt request for organisasjoner innlogget brukeren har rettigheter i")
 
+        logger.info("Mottatt request for organisasjoner innlogget brukeren har rettigheter i")
         val validertQuery = validerOgFiltrerQuery(query)
 
-        val responsetidPerKlient: Timer = MetricsFactory
-                .createTimer(
-                "altinn-rettigheter-proxy.reportees.responsetid.${consumerId?:"UKJENT_KLIENT_APP"}")
-                .start()
-        val responsetidAlleKlienter: Timer = MetricsFactory
-                .createTimer(
-                        "altinn-rettigheter-proxy.reportees.responsetid.alle")
-                .start()
-
+        val responsetidPerKlient: Timer = startResponseTidPerKlient(consumerId)
+        val responsetidAlleKlienter: Timer = startResponseTidAlleKlienter()
 
         val organisasjoner = altinnrettigheterService.hentOrganisasjoner(
                 validertQuery,
@@ -60,14 +75,69 @@ class AltinnrettigheterProxyController(val altinnrettigheterService: Altinnretti
         )
         responsetidPerKlient.stop().report()
         responsetidAlleKlienter.stop().report()
-
-        MetricsFactory.createEvent("altinn-rettigheter-proxy.reportees")
-                .addTagToReport("klientapp", consumerId?:"UKJENT_KLIENT_APP")
-                .report()
+        reportKallTilEndepunkt(consumerId)
 
         return organisasjoner
     }
 
+    private fun hentOrganisasjoner(
+            inkluderAlle: Boolean,
+            serviceCode: String,
+            serviceEdition: String,
+            fnr: Fnr
+    ): List<AltinnOrganisasjon> {
+        val altinnOrganisasjoner = mutableSetOf<AltinnOrganisasjon>()
+        var hasMore = true
+        var pageNumber = 0
+
+        if (inkluderAlle) {
+            while (hasMore) {
+                pageNumber++
+                val organisasjoner = altinnrettigheterService.hentOrganisasjoner(
+                        mapOf(
+                                "ForceEIAuthentication" to "",
+                                "serviceCode" to serviceCode,
+                                "serviceEdition" to serviceEdition,
+                                "\$top" to altinnReporteesPageSize,
+                                "\$skip" to ((pageNumber - 1) * Integer.valueOf(altinnReporteesPageSize)).toString()
+                        ),
+                        fnr
+                )
+                altinnOrganisasjoner.addAll(organisasjoner)
+                hasMore = organisasjoner.size >= Integer.valueOf(altinnReporteesPageSize)
+            }
+            return ArrayList(altinnOrganisasjoner)
+        } else {
+            return altinnrettigheterService.hentOrganisasjoner(
+                    mapOf(
+                            "ForceEIAuthentication" to "",
+                            "serviceCode" to serviceCode,
+                            "serviceEdition" to serviceEdition
+                    ),
+                    fnr
+            )
+        }
+    }
+
+    private fun startResponseTidPerKlient(consumerId: String?): Timer {
+        return MetricsFactory
+                .createTimer(
+                        "altinn-rettigheter-proxy.reportees.responsetid.${consumerId?:"UKJENT_KLIENT_APP"}")
+                .start()
+    }
+
+    private fun startResponseTidAlleKlienter(): Timer {
+        return MetricsFactory
+                .createTimer(
+                        "altinn-rettigheter-proxy.reportees.responsetid.alle")
+                .start()
+    }
+
+    private fun reportKallTilEndepunkt(consumerId: String?) {
+        MetricsFactory.createEvent("altinn-rettigheter-proxy.reportees")
+                .addTagToReport("klientapp", consumerId?:"UKJENT_KLIENT_APP")
+                .report()
+    }
 
     private fun validerOgFiltrerQuery(query: Map<String, String>): Map<String, String> {
         validerObligatoriskeParametre(query,"ForceEIAuthentication")
@@ -89,5 +159,4 @@ class AltinnrettigheterProxyController(val altinnrettigheterService: Altinnretti
             )
         }
     }
-
 }

--- a/src/main/kotlin/no/nav/arbeidsgiver/altinnrettigheter/proxy/controller/AltinnrettigheterProxyController.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/altinnrettigheter/proxy/controller/AltinnrettigheterProxyController.kt
@@ -91,6 +91,8 @@ class AltinnrettigheterProxyController(
         var pageNumber = 0
 
         if (inkluderAlle) {
+            val filterParamVerdi = "Type+ne+'Person'+and+Status+eq+'Active'"
+
             while (hasMore) {
                 pageNumber++
                 val organisasjoner = altinnrettigheterService.hentOrganisasjoner(
@@ -99,7 +101,8 @@ class AltinnrettigheterProxyController(
                                 "serviceCode" to serviceCode,
                                 "serviceEdition" to serviceEdition,
                                 "\$top" to altinnReporteesPageSize,
-                                "\$skip" to ((pageNumber - 1) * Integer.valueOf(altinnReporteesPageSize)).toString()
+                                "\$skip" to ((pageNumber - 1) * Integer.valueOf(altinnReporteesPageSize)).toString(),
+                                "\$filter" to filterParamVerdi
                         ),
                         fnr
                 )

--- a/src/main/kotlin/no/nav/arbeidsgiver/altinnrettigheter/proxy/mockserver/MockServer.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/altinnrettigheter/proxy/mockserver/MockServer.kt
@@ -46,6 +46,7 @@ class MockServer @Autowired constructor(
                  "$altinnPathToReportees"
                  + "&\$top=5"
                  + "&\$skip=0"
+                 + "&\$filter=Type+ne+'Person'+and+Status+eq+'Active'"
                  + "&subject=01065500791",
         "altinnReportees-del1.json"
          )
@@ -54,6 +55,7 @@ class MockServer @Autowired constructor(
                  "$altinnPathToReportees"
                          + "&\$top=5"
                          + "&\$skip=5"
+                         + "&\$filter=Type+ne+'Person'+and+Status+eq+'Active'"
                          + "&subject=01065500791",
                  "altinnReportees-del2.json"
          )

--- a/src/main/kotlin/no/nav/arbeidsgiver/altinnrettigheter/proxy/mockserver/MockServer.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/altinnrettigheter/proxy/mockserver/MockServer.kt
@@ -10,9 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Profile
 import org.springframework.stereotype.Component
-import java.io.UnsupportedEncodingException
 import java.net.URL
-import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 
 @Profile("local")
@@ -24,6 +22,8 @@ class MockServer @Autowired constructor(
         val altinnUrl: String
 ) {
 
+    private val MOCK_SERVER_DEBUG_ENABLED = false;
+
     init {
         System.out.println("mocking")
         val server = WireMockServer(
@@ -33,7 +33,7 @@ class MockServer @Autowired constructor(
                                 ResponseTemplateTransformer(true)
                         )
                         .notifier(
-                                ConsoleNotifier(true)
+                                ConsoleNotifier(MOCK_SERVER_DEBUG_ENABLED)
                         )
         )
         val altinnPathToReportees = URL(altinnUrl).path + "ekstern/altinn/api/serviceowner/reportees?" +

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -17,6 +17,8 @@ spring:
   profiles: test
 
 altinn:
+  reportees:
+    pagesize: 5
   url: "http://local.test"
   apikey: "test"
   apigw.apikey: "test"
@@ -44,6 +46,8 @@ mock:
   aktorPort: 9092
 
 altinn:
+  reportees:
+    pagesize: 5
   url: "http://localhost:${mock.port}/altinn/"
   apikey: "test"
   apigw.apikey: "test"
@@ -72,6 +76,8 @@ spring:
       time-to-live: ${CACHE_TIME_TO_LIVE_MILLIS}
 
 altinn:
+  reportees:
+    pagesize: 500
   url: "https://api-gw-q1.adeo.no/"
 
 no.nav.security.oidc:
@@ -95,6 +101,8 @@ spring:
       time-to-live: ${CACHE_TIME_TO_LIVE_MILLIS}
 
 altinn:
+  reportees:
+    pagesize: 500
   url: "https://api-gw.adeo.no/"
 
 no.nav.security.oidc:

--- a/src/main/resources/mock/altinnReportees-del1.json
+++ b/src/main/resources/mock/altinnReportees-del1.json
@@ -1,0 +1,42 @@
+[
+  {
+    "Name": "BALLSTAD OG HAMARØY",
+    "Type": "Business",
+    "OrganizationNumber": "811076732",
+    "ParentOrganizationNumber": "811076112",
+    "OrganizationForm": "BEDR",
+    "Status": "Active"
+  },
+  {
+    "Name": "BALLSTAD OG HORTEN",
+    "Type": "Enterprise",
+    "ParentOrganizationNumber": null,
+    "OrganizationNumber": "811076112",
+    "OrganizationForm": "AS",
+    "Status": "Active"
+  },
+  {
+    "Name": "NAV ARBEID OG YTELSER",
+    "Type": "Enterprise",
+    "ParentOrganizationNumber": null,
+    "OrganizationNumber": "999263550",
+    "OrganizationForm": "AS",
+    "Status": "Active"
+  },
+  {
+    "Name": "DIGITAL JUNKIES AS ",
+    "Type": "Enterprise",
+    "OrganizationNumber": "822565212",
+    "ParentOrganizationNumber": null,
+    "OrganizationForm": "AS",
+    "Status": "Active"
+  },
+  {
+    "Name": "DIGITAL JUNKIES AS ",
+    "Type": "Business",
+    "OrganizationNumber": "922658986",
+    "ParentOrganizationNumber": "822565212",
+    "OrganizationForm": "BEDR",
+    "Status": "Active"
+  }
+]

--- a/src/main/resources/mock/altinnReportees-del2.json
+++ b/src/main/resources/mock/altinnReportees-del2.json
@@ -1,0 +1,34 @@
+[
+  {
+    "Name": "NAV ENGERDAL",
+    "Type": "Business",
+    "ParentOrganizationNumber": "874652202",
+    "OrganizationNumber": "991378642",
+    "OrganizationForm": "BEDR",
+    "Status": "Active"
+  },
+  {
+    "Name": "NAV HAMAR",
+    "Type": "Business",
+    "ParentOrganizationNumber": "874652202",
+    "OrganizationNumber": "990229023",
+    "OrganizationForm": "BEDR",
+    "Status": "Active"
+  },
+  {
+    "Name": "NAV HAMAR 2",
+    "Type": "Business",
+    "ParentOrganizationNumber": "874652202",
+    "OrganizationNumber": "910969439",
+    "OrganizationForm": "BEDR",
+    "Status": "Active"
+  },
+  {
+    "Name": "NAV HAMAR 3",
+    "Type": "Business",
+    "ParentOrganizationNumber": "874652202",
+    "OrganizationNumber": "444444444",
+    "OrganizationForm": "BEDR",
+    "Status": "Active"
+  }
+]


### PR DESCRIPTION
Legge til mulighet til å hente alle organisasjoner en bruker har enkelte rettigheter i (default er 50 maks) dersom man setter _optional_ parameteren `inkluderAlle` til `true` ved bruk av `/organisasjoner` endepunktet
Når parameteren er på, da skal proxy kalle Altinn med query parametre `$top`, `$skip` og `$filter`. 