### PR TITLE
send parametere til resttemplate slik at metrikker ikke eksploderer

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ jobs:
     #########################
     ### DEVELOPERS: Insert your feature branch name below (in addition to master) if you want to deploy it to dev
     #########################
-    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/tokenx_support'
+    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/bugfix_uri_emtrics'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1


### PR DESCRIPTION
v ifikk oom i prod og manglende metrikker som sannsynligvis er en følge av økt volum og at man i klienten bygger url selv, slik at metrikker ikke blir gruppert riktig.