### PR TITLE
fiks bug mellom klient og proxy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ jobs:
     #########################
     ### DEVELOPERS: Insert your feature branch name below (in addition to master) if you want to deploy it to dev
     #########################
-    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/forbedre_timeouts_mot_altinn'
+    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/TAG-1787'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1

--- a/src/main/kotlin/no/nav/arbeidsgiver/altinnrettigheter/proxy/controller/AltinnrettigheterProxyController.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/altinnrettigheter/proxy/controller/AltinnrettigheterProxyController.kt
@@ -51,7 +51,8 @@ class AltinnrettigheterProxyController(
             @RequestParam(required = false) serviceEdition: String?,
             @RequestParam top: Number,
             @RequestParam skip: Number,
-            @RequestParam(required = false, defaultValue = "true") filterPaaAktiveOrganisasjoner: String
+            @RequestParam(required = false, defaultValue = "true") filterPaaAktiveOrganisasjoner: String,
+            @RequestParam(required = false) filter: String?
     ): List<AltinnOrganisasjon> {
         sjekkParametreInneholderSifre(
                 mapOf(
@@ -68,7 +69,9 @@ class AltinnrettigheterProxyController(
                 "\$skip" to "$skip"
         )
 
-        if (filterPaaAktiveOrganisasjoner == "true") {
+        if (filter != null && filter.isNotEmpty()) {
+            queryParametre["\$filter"] = filter
+        } else if (filterPaaAktiveOrganisasjoner == "true") {
             queryParametre["\$filter"] = "Type ne 'Person' and Status eq 'Active'"
         }
 


### PR DESCRIPTION
Legger til en bakover kompatibel endring i apiet slik at filter som sendes fra klienten respekteres.

fixes: https://jira.adeo.no/browse/TAG-1787

---
note:
Bør på sikt se på å fjerne filterPaaAktiveOrganisasjoner parameter fra apiet, men må se at det ikke er i bruk først. Klienten setter det ikke, men det kan være noen som kaller apiet direkte som setter det. 