### PR TITLE
Endrer workflow til kun deploye redis dersom det er endringer i configen

### DIFF
--- a/.github/workflows/deploy-redis.yml
+++ b/.github/workflows/deploy-redis.yml
@@ -1,0 +1,34 @@
+name: Deploy Redis
+
+on:
+  push:
+    paths: ['nais/redis-gcp.yaml']
+  workflow_dispatch:
+
+jobs:
+  ###### GCP DEV
+  deploy-redis-dev-gcp:
+    name: Deploy redis dev-gcp
+    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/TAG-1787'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: nais/deploy/actions/deploy@v1
+        env:
+          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
+          CLUSTER: dev-gcp
+          RESOURCE: nais/redis-gcp.yaml
+
+  ###### GCP PROD
+  deploy-redis-prod-gcp:
+    name: Deploy redis prod-gcp
+    needs: deploy-redis-dev-gcp
+    if: github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: nais/deploy/actions/deploy@v1
+        env:
+          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
+          CLUSTER: prod-gcp
+          RESOURCE: nais/redis-gcp.yaml

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,19 +55,6 @@ jobs:
           docker push ${IMAGE}
 
   ###### GCP DEV
-
-  deploy-redis-dev-gcp:
-    name: Deploy redis dev-gcp
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-      - uses: nais/deploy/actions/deploy@v1
-        env:
-          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
-          CLUSTER: dev-gcp
-          RESOURCE: nais/redis-gcp.yaml
-
   deploy-server-dev-gcp:
     name: Deploy server dev-gcp
     needs: build
@@ -82,23 +69,9 @@ jobs:
           RESOURCE: nais/dev-gcp.yaml
 
   ###### GCP PROD
-
-  deploy-redis-prod-gcp:
-    name: Deploy redis prod-gcp
-    needs: [ deploy-server-dev-gcp, deploy-redis-dev-gcp ]
-    if: github.ref == 'refs/heads/master'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-      - uses: nais/deploy/actions/deploy@v1
-        env:
-          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
-          CLUSTER: prod-gcp
-          RESOURCE: nais/redis-gcp.yaml
-
   deploy-server-prod-gcp:
     name: Deploy server prod-gcp
-    needs: [ deploy-server-dev-gcp, deploy-redis-dev-gcp ]
+    needs: deploy-server-dev-gcp
     if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
virker som det er en god del støy i loggene som korrelerer med når vi merger og deployer proxyen.
mistenker at det blir litt mindre støy hvis vi ikke drar opp og ned redis når det ikke er nødvendig.