### PR TITLE
dobler redis timeout og cache ttl

### DIFF
--- a/nais/prod-gcp.yaml
+++ b/nais/prod-gcp.yaml
@@ -85,7 +85,7 @@ spec:
     - name: REDIS_HOST
       value: altinn-rettigheter-proxy-redis.arbeidsgiver.svc.cluster.local
     - name: CACHE_TIME_TO_LIVE_MILLIS
-      value: "600000"
+      value: "1200000"
     - name: ALTINN_URL
       value: "https://api-gw.oera.no/"
   envFrom:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -5,7 +5,7 @@ spring:
     host: ${REDIS_HOST}
     port: 6379
     password: ${REDIS_PASSWORD}
-    timeout: 1000
+    timeout: 2000
     lettuce:
       pool:
         max-active: 16


### PR DESCRIPTION
det er mye mindre connection feil nå enn før, ser om en liten økning i timeout hjelper ytterligere

vi bruker forholdsvis lite av tilgjengelig minne, så jeg prøver å justere opp cache ttl litt.