### PR TITLE
Hent ut app navn fra tokenx-tokens

### DIFF
--- a/src/main/kotlin/no/nav/arbeidsgiver/altinnrettigheter/proxy/controller/AltinnrettigheterProxyController.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/altinnrettigheter/proxy/controller/AltinnrettigheterProxyController.kt
@@ -29,18 +29,17 @@ class AltinnrettigheterProxyController(
             @RequestHeader(value = "X-Consumer-ID", required = false) consumerId: String?,
             @RequestParam serviceCode: String, @RequestParam serviceEdition: String
     ): List<AltinnOrganisasjon> {
-
         return proxyOrganisasjoner(
-                consumerId,
-                host,
-                mapOf(
+                consumerId = consumerId,
+                host = host,
+                query = mapOf(
                         "ForceEIAuthentication" to "",
                         "serviceCode" to serviceCode,
                         "serviceEdition" to serviceEdition,
                         "\$filter" to "Type+ne+'Person'+and+Status+eq+'Active'",
                         "\$top" to "500",
                         "\$skip" to "0"
-                )
+                ),
         )
     }
 
@@ -84,10 +83,10 @@ class AltinnrettigheterProxyController(
             queryParametre["serviceEdition"] = serviceEdition
         }
 
-        return proxyOrganisasjoner(
-                consumerId,
-                host,
-                queryParametre
+        return hentOrganisasjoner(
+                consumerId = consumerId,
+                host = host,
+                query = queryParametre,
         )
     }
 
@@ -97,11 +96,22 @@ class AltinnrettigheterProxyController(
             @RequestHeader(value = "host", required = false) host: String?,
             @RequestParam query: Map<String, String>
     ): List<AltinnOrganisasjon> {
+        return hentOrganisasjoner(
+            query = query,
+            host = host,
+            consumerId = consumerId
+        )
+    }
+
+    private fun hentOrganisasjoner(
+        query: Map<String, String>,
+        consumerId: String?,
+        host: String?,
+    ): List<AltinnOrganisasjon> {
         logger.info("Mottatt request for organisasjoner innlogget brukeren har rettigheter i")
-
         val validertQuery = validerOgFiltrerQuery(query)
-
-        return withTimer(consumerId ?: "UKJENT_KLIENT_APP", host) {
+        val callingApp = tilgangskontrollService.nameOfAppCallingUs()
+        return withTimer(callingApp ?: consumerId ?: "UKJENT_KLIENT_APP", host) {
             altinnrettigheterService.hentOrganisasjoner(
                 validertQuery,
                 tilgangskontrollService.hentInnloggetBruker().fnr

--- a/src/main/kotlin/no/nav/arbeidsgiver/altinnrettigheter/proxy/controller/AltinnrettigheterProxyController.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/altinnrettigheter/proxy/controller/AltinnrettigheterProxyController.kt
@@ -29,7 +29,7 @@ class AltinnrettigheterProxyController(
             @RequestHeader(value = "X-Consumer-ID", required = false) consumerId: String?,
             @RequestParam serviceCode: String, @RequestParam serviceEdition: String
     ): List<AltinnOrganisasjon> {
-        return proxyOrganisasjoner(
+        return hentOrganisasjoner(
                 consumerId = consumerId,
                 host = host,
                 query = mapOf(

--- a/src/main/kotlin/no/nav/arbeidsgiver/altinnrettigheter/proxy/tilgangskontroll/TilgangskontrollService.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/altinnrettigheter/proxy/tilgangskontroll/TilgangskontrollService.kt
@@ -50,6 +50,12 @@ class TilgangskontrollService(
         throw TilgangskontrollException("Finner ikke token")
     }
 
+    fun nameOfAppCallingUs(): String? =
+        tokenValidationcontextHolder
+            .tokenValidationContext
+            .getClaimsFor(ISSUER_TOKENX)
+            ?.getStringClaim("client_id")
+
     private fun JwtTokenClaims.getTokenXFnr(): String {
         /* NOTE: This is not validation of original issuer. We trust TokenX to only issue
          * tokens from trustworthy sources. The purpose is simply to differentiate different


### PR DESCRIPTION
Hvis kallet mot oss er gjort med TokenX, så kan vi  hente ut navnet på appen. Så slipper vi knot med consumer-id og folk som glemmer consumer id eller bruker samme consumer-id på flere apper.

~~Venter på bekreftelse på om~~ dette er ok bruk av `client_id`:  https://nav-it.slack.com/archives/C010S0X1ABD/p1641998670015900