### PR TITLE
Tillatt kall fra forebyggingsplan i teamia namespace

### DIFF
--- a/nais/dev-gcp.yaml
+++ b/nais/dev-gcp.yaml
@@ -63,7 +63,7 @@ spec:
           namespace: fager
 
         - application: ia-tjenester-metrikker
-        
+
         - application: notifikasjon-bruker-api
           namespace: fager
 
@@ -85,16 +85,16 @@ spec:
 
         - application: yrkesskade-melding-api
           namespace: yrkesskade
-          
+
         - application: forebyggingsplan
-          namespace: pia
-         
+          namespace: teamia
+
         - application: sosialhjelp-avtaler-api-dev
           namespace: teamdigisos
 
         - application: presenterte-kandidater-api
           namespace: toi
-         
+
 
     outbound:
       rules:


### PR DESCRIPTION
Vi overfører eierskap til forebyggingsplan fra team Pia til team IA og flytter applikasjonen til namespace `teamia`.
Trenger dermed å tillatte kall for forebyggingsplan i namespace `teamia` (først i `dev-gcp`)