### PR TITLE
make sure clients can call endpoints using trailing slash

### DIFF
--- a/src/main/kotlin/no/nav/arbeidsgiver/altinnrettigheter/proxy/controller/AltinnrettigheterProxyController.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/altinnrettigheter/proxy/controller/AltinnrettigheterProxyController.kt
@@ -23,7 +23,7 @@ class AltinnrettigheterProxyController(
 
     private val logger = LoggerFactory.getLogger(javaClass)
 
-    @GetMapping(value = ["/organisasjoner"])
+    @GetMapping("/organisasjoner", "/organisasjoner/")
     fun proxyOrganisasjonerNY(
         @RequestHeader(value = "host", required = false) host: String?,
         @RequestHeader(value = "X-Consumer-ID", required = false) consumerId: String?,
@@ -43,7 +43,7 @@ class AltinnrettigheterProxyController(
         )
     }
 
-    @GetMapping("/v2/organisasjoner")
+    @GetMapping("/v2/organisasjoner", "/v2/organisasjoner/")
     fun proxyOrganisasjonerV2(
         @RequestHeader(value = "host", required = false) host: String?,
         @RequestHeader(value = "X-Consumer-ID") consumerId: String,
@@ -88,7 +88,7 @@ class AltinnrettigheterProxyController(
         )
     }
 
-    @GetMapping(value = ["/ekstern/altinn/api/serviceowner/reportees"])
+    @GetMapping("/ekstern/altinn/api/serviceowner/reportees", "/ekstern/altinn/api/serviceowner/reportees/")
     fun proxyOrganisasjoner(
         @RequestHeader(value = "X-Consumer-ID", required = false) consumerId: String?,
         @RequestHeader(value = "host", required = false) host: String?,

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -31,9 +31,15 @@ server:
   servlet:
     context-path: /altinn-rettigheter-proxy
 
-management.endpoints.web:
-  exposure.include: info, health, metrics, prometheus
-  base-path: /internal/actuator
+management:
+  endpoints.web:
+    exposure.include: info, health, metrics, prometheus
+    base-path: /internal/actuator
+  metrics.distribution:
+    percentiles-histogram:
+      http.server.requests: true
+    percentiles:
+      http.server.requests: 0.99,0.95,0.90,0.80,0.50
 
 no.nav.security.jwt:
   issuer:


### PR DESCRIPTION
"As of Spring Framework 6.0, the trailing slash matching configuration option has been deprecated and its default value set to false"
- https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.0-Migration-Guide#web-application-changes