### PR TITLE
Endrer dev-ingresser til ".intern.dev"

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ accessPolicy:
 
 Vi anbefaler på det sterkeste å bruke TokenX, da vi ønsker å fjerne støtten for å bruke loginservice direkte.
 
-I dev, så er det også en vanlig ingress tilgjengelig, `https://altinn-rettigheter-proxy.dev.nav.no/altinn-rettigheter-proxy`, som dere kan bruke uten å måtte oppdatere vår access policy.
+I dev, så er det også en vanlig ingress tilgjengelig, `https://altinn-rettigheter-proxy.intern.dev.nav.no/altinn-rettigheter-proxy`, som dere kan bruke uten å måtte oppdatere vår access policy.
 
 # Hvordan ta i bruk proxyen (FSS)
-Fra FSS kan dere nå oss med ingressen `https://altinn-rettigheter-proxy.intern.nav.no/altinn-rettigheter-proxy/`. I dev er URL-en `https://altinn-rettigheter-proxy.dev.intern.nav.no/altinn-rettigheter-proxy`.
+Fra FSS kan dere nå oss med ingressen `https://altinn-rettigheter-proxy.intern.nav.no/altinn-rettigheter-proxy/`. I dev er URL-en `https://altinn-rettigheter-proxy.intern.dev.nav.no/altinn-rettigheter-proxy`.
 For at den skal fungere, må dere være lagt inn i access policy-en vår i [nais/prod-gcp.yaml](https://github.com/navikt/altinn-rettigheter-proxy/blob/master/nais/prod-gcp.yaml) og [nais/dev-gcp.yaml](https://github.com/navikt/altinn-rettigheter-proxy/blob/master/nais/dev-gcp.yaml), slik:
 ```yaml
 accessPolicy:

--- a/nais/dev-gcp.yaml
+++ b/nais/dev-gcp.yaml
@@ -10,8 +10,9 @@ spec:
   team: arbeidsgiver
   port: 8080
   ingresses:
-    - https://altinn-rettigheter-proxy.dev.intern.nav.no/altinn-rettigheter-proxy
-    - https://altinn-rettigheter-proxy.dev.nav.no/altinn-rettigheter-proxy
+    - https://altinn-rettigheter-proxy.intern.dev.nav.no/altinn-rettigheter-proxy
+    - https://altinn-rettigheter-proxy.dev.intern.nav.no/altinn-rettigheter-proxy  # deprecated
+    - https://altinn-rettigheter-proxy.dev.nav.no/altinn-rettigheter-proxy  # deprecated
   liveness:
     path: /altinn-rettigheter-proxy/internal/alive
     initialDelay: 60

--- a/nais/dev-gcp.yaml
+++ b/nais/dev-gcp.yaml
@@ -11,8 +11,8 @@ spec:
   port: 8080
   ingresses:
     - https://altinn-rettigheter-proxy.intern.dev.nav.no/altinn-rettigheter-proxy
-    - https://altinn-rettigheter-proxy.dev.intern.nav.no/altinn-rettigheter-proxy  # deprecated
-    - https://altinn-rettigheter-proxy.dev.nav.no/altinn-rettigheter-proxy  # deprecated
+    - https://altinn-rettigheter-proxy.dev.intern.nav.no/altinn-rettigheter-proxy # Slutter å fungere etter 02.05.23
+    - https://altinn-rettigheter-proxy.dev.nav.no/altinn-rettigheter-proxy  # Slutter å fungere etter 02.05.23
   liveness:
     path: /altinn-rettigheter-proxy/internal/alive
     initialDelay: 60


### PR DESCRIPTION
`*dev.intern.nav.no` og `*.dev.nav.no` skrus av i dev-gcp 2. mai 2023

Se [Slack-tråd](https://nav-it.slack.com/archives/C01DE3M9YBV/p1681202269927439?thread_ts=1677747333.208699&cid=C01DE3M9YBV) i #nais-announcements
