### PR TITLE
Fjern accesspolicy for permitteringsportal.

### DIFF
--- a/nais/dev-gcp.yaml
+++ b/nais/dev-gcp.yaml
@@ -62,9 +62,6 @@ spec:
         - application: permitteringsskjema-api
           namespace: permittering-og-nedbemanning
 
-        - application: permitteringsportal-api
-          namespace: permittering-og-nedbemanning
-
         - application: aareg-innsyn-arbeidsgiver-api
           namespace: arbeidsforhold
           cluster: dev-fss


### PR DESCRIPTION
Den eksisterer ikke.