### PR TITLE
flytt ut fra arbeidgiver namespace

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,6 +1,7 @@
 name: Deploy dev
 
-on: [workflow_dispatch]
+on:
+  workflow_dispatch:
 
   
 jobs:

--- a/.github/workflows/deploy-redis.yml
+++ b/.github/workflows/deploy-redis.yml
@@ -2,12 +2,14 @@ name: Deploy Redis
 
 on:
   push:
-    paths: ['nais/redis-dev-gcp.yaml', 'nais/redis-prod-gcp.yaml']
+    paths:
+      - nais/redis-dev-gcp.yaml
+      - nais/redis-prod-gcp.yaml
   workflow_dispatch:
 
 jobs:
   deploy-redis-dev-gcp:
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/revert-160-revert-157-TAG-2172_nais_aiven_redis'
+    if: github.ref == 'refs/heads/main' || github.ref == 'mv_arbeidsgiver_fager'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -17,7 +19,7 @@ jobs:
           RESOURCE: nais/redis-dev-gcp.yaml
 
   deploy-redis-prod-gcp:
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/TAG-2172_nais_aiven_redis'
+    if: github.ref == 'refs/heads/main'
     needs: deploy-redis-dev-gcp
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/deploy-redis.yml
+++ b/.github/workflows/deploy-redis.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   deploy-redis-dev-gcp:
-    if: github.ref == 'refs/heads/main' || github.ref == 'mv_arbeidsgiver_fager'
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/mv_arbeidsgiver_fager'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/deploy-redis.yml
+++ b/.github/workflows/deploy-redis.yml
@@ -11,6 +11,9 @@ jobs:
   deploy-redis-dev-gcp:
     if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/mv_arbeidsgiver_fager'
     runs-on: ubuntu-latest
+    permissions:
+      contents: "read"
+      id-token: "write"
     steps:
       - uses: actions/checkout@v4
       - uses: nais/deploy/actions/deploy@v2
@@ -22,6 +25,9 @@ jobs:
     if: github.ref == 'refs/heads/main'
     needs: deploy-redis-dev-gcp
     runs-on: ubuntu-latest
+    permissions:
+      contents: "read"
+      id-token: "write"
     steps:
       - uses: actions/checkout@v4
       - uses: nais/deploy/actions/deploy@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
 FROM gcr.io/distroless/java21-debian12
 COPY /target/altinn-rettigheter-proxy-0.0.1-SNAPSHOT.jar app.jar
+
+ENV JDK_JAVA_OPTIONS="-XX:MaxRAMPercentage=75"
 CMD ["app.jar"]

--- a/nais/arbeidsgiver-dev-gcp.yaml
+++ b/nais/arbeidsgiver-dev-gcp.yaml
@@ -2,26 +2,18 @@ apiVersion: nais.io/v1alpha1
 kind: Application
 metadata:
   name: altinn-rettigheter-proxy
-  namespace: fager
+  namespace: arbeidsgiver
   labels:
-    team: fager
+    team: arbeidsgiver
 spec:
   image: {{image}}
   port: 8080
-  resources:
-    requests:
-      cpu: 1000m
-      memory: 512Mi
-    limits:
-      cpu: 5000m # https://home.robusta.dev/blog/stop-using-cpu-limits/
-      memory: 1024Mi
+  ingresses:
+    - https://altinn-rettigheter-proxy.intern.dev.nav.no/altinn-rettigheter-proxy
   liveness:
     path: /altinn-rettigheter-proxy/internal/alive
   readiness:
     path: /altinn-rettigheter-proxy/internal/ready
-  prometheus:
-    enabled: true
-    path: /altinn-rettigheter-proxy/internal/actuator/prometheus
   tokenx:
     enabled: true
   maskinporten:
@@ -32,33 +24,42 @@ spec:
   redis:
     - instance: altinnrettigheter
       access: readwrite
+  env:
+    - name: SPRING_PROFILES_ACTIVE
+      value: dev
+    - name: CACHE_TIME_TO_LIVE_MILLIS
+      value: "600000"
+    - name: ALTINN_URL
+      value: "https://tt02.altinn.no"
+  envFrom:
+    - secret: altinn-rettigheter-proxy
   accessPolicy:
     inbound:
       rules:
-
         - application: sykefravarsstatistikk-api
           namespace: arbeidsgiver
-          cluster: prod-fss
+          cluster: dev-fss
 
         - application: tiltaksgjennomforing-api
           namespace: arbeidsgiver
-          cluster: prod-fss
+          cluster: dev-fss
 
         - application: ia-tjenester-metrikker
-          namespace: arbeidsgiver
 
         - application: tiltak-refusjon-api
-          namespace: arbeidsgiver
 
         - application: aareg-innsyn-arbeidsgiver-api
           namespace: arbeidsforhold
-          cluster: prod-fss
+          cluster: dev-fss
 
-        - application: sosialhjelp-avtaler-api
-          namespace: teamdigisos
+        - application: yrkesskade-melding-api
+          namespace: yrkesskade
 
         - application: forebyggingsplan
           namespace: teamia
+
+        - application: sosialhjelp-avtaler-api-dev
+          namespace: teamdigisos
 
         - application: presenterte-kandidater-api
           namespace: toi
@@ -66,23 +67,23 @@ spec:
         - application: fia-arbeidsgiver
           namespace: pia
 
+        - application: dsop-kontroll-q1
+          namespace: dsopkontroll
+          cluster: dev-fss
+
         - application: dsop-kontroll
           namespace: dsopkontroll
-          cluster: prod-fss
+          cluster: dev-fss
 
         - application: fpinntektsmelding
           namespace: teamforeldrepenger
 
+        - application: k9-inntektsmelding
+          namespace: k9saksbehandling
     outbound:
       external:
-        - host: www.altinn.no
+        - host: tt02.altinn.no
+  prometheus:
+    enabled: true
+    path:  /altinn-rettigheter-proxy/internal/actuator/prometheus
 
-  env:
-    - name: SPRING_PROFILES_ACTIVE
-      value: prod
-    - name: CACHE_TIME_TO_LIVE_MILLIS
-      value: "1800000"
-    - name: ALTINN_URL
-      value: "https://www.altinn.no/"
-  envFrom:
-    - secret: altinn-rettigheter-proxy

--- a/nais/arbeidsgiver-prod-gcp.yaml
+++ b/nais/arbeidsgiver-prod-gcp.yaml
@@ -2,11 +2,11 @@ apiVersion: nais.io/v1alpha1
 kind: Application
 metadata:
   name: altinn-rettigheter-proxy
-  namespace: fager
+  namespace: arbeidsgiver
   labels:
-    team: fager
+    team: arbeidsgiver
 spec:
-  image: {{image}}
+  image: {{ image }}
   port: 8080
   resources:
     requests:
@@ -19,9 +19,8 @@ spec:
     path: /altinn-rettigheter-proxy/internal/alive
   readiness:
     path: /altinn-rettigheter-proxy/internal/ready
-  prometheus:
-    enabled: true
-    path: /altinn-rettigheter-proxy/internal/actuator/prometheus
+  ingresses:
+    - https://altinn-rettigheter-proxy.intern.nav.no/altinn-rettigheter-proxy/
   tokenx:
     enabled: true
   maskinporten:
@@ -45,10 +44,8 @@ spec:
           cluster: prod-fss
 
         - application: ia-tjenester-metrikker
-          namespace: arbeidsgiver
 
         - application: tiltak-refusjon-api
-          namespace: arbeidsgiver
 
         - application: aareg-innsyn-arbeidsgiver-api
           namespace: arbeidsforhold
@@ -62,9 +59,9 @@ spec:
 
         - application: presenterte-kandidater-api
           namespace: toi
-
+          
         - application: fia-arbeidsgiver
-          namespace: pia
+          namespace: pia         
 
         - application: dsop-kontroll
           namespace: dsopkontroll
@@ -84,5 +81,10 @@ spec:
       value: "1800000"
     - name: ALTINN_URL
       value: "https://www.altinn.no/"
+    - name: JAVA_OPTS
+      value: "-XX:+UseParallelGC -XX:MaxRAMPercentage=75.0 -XX:ActiveProcessorCount=2"
   envFrom:
     - secret: altinn-rettigheter-proxy
+  prometheus:
+    enabled: true
+    path: /altinn-rettigheter-proxy/internal/actuator/prometheus

--- a/nais/arbeidsgiver-redis-dev-gcp.yaml
+++ b/nais/arbeidsgiver-redis-dev-gcp.yaml
@@ -3,9 +3,9 @@ kind: Redis
 metadata:
   labels:
     app: altinn-rettigheter-proxy-redis
-    team: fager
+    team: arbeidsgiver
   name: redis-arbeidsgiver-altinnrettigheter
-  namespace: fager
+  namespace: arbeidsgiver
 spec:
   plan: startup-4
-  project: nav-prod
+  project: nav-dev

--- a/nais/arbeidsgiver-redis-prod-gcp.yaml
+++ b/nais/arbeidsgiver-redis-prod-gcp.yaml
@@ -3,9 +3,9 @@ kind: Redis
 metadata:
   labels:
     app: altinn-rettigheter-proxy-redis
-    team: fager
+    team: arbeidsgiver
   name: redis-arbeidsgiver-altinnrettigheter
-  namespace: fager
+  namespace: arbeidsgiver
 spec:
   plan: startup-4
   project: nav-prod

--- a/nais/dev-gcp.yaml
+++ b/nais/dev-gcp.yaml
@@ -2,18 +2,19 @@ apiVersion: nais.io/v1alpha1
 kind: Application
 metadata:
   name: altinn-rettigheter-proxy
-  namespace: arbeidsgiver
+  namespace: fager
   labels:
-    team: arbeidsgiver
+    team: fager
 spec:
   image: {{image}}
   port: 8080
-  ingresses:
-    - https://altinn-rettigheter-proxy.intern.dev.nav.no/altinn-rettigheter-proxy
   liveness:
     path: /altinn-rettigheter-proxy/internal/alive
   readiness:
     path: /altinn-rettigheter-proxy/internal/ready
+  prometheus:
+    enabled: true
+    path: /altinn-rettigheter-proxy/internal/actuator/prometheus
   tokenx:
     enabled: true
   maskinporten:
@@ -45,8 +46,10 @@ spec:
           cluster: dev-fss
 
         - application: ia-tjenester-metrikker
+          namespace: arbeidsgiver
 
         - application: tiltak-refusjon-api
+          namespace: arbeidsgiver
 
         - application: aareg-innsyn-arbeidsgiver-api
           namespace: arbeidsforhold
@@ -83,7 +86,4 @@ spec:
     outbound:
       external:
         - host: tt02.altinn.no
-  prometheus:
-    enabled: true
-    path:  /altinn-rettigheter-proxy/internal/actuator/prometheus
 

--- a/nais/dev-gcp.yaml
+++ b/nais/dev-gcp.yaml
@@ -8,6 +8,9 @@ metadata:
 spec:
   image: {{image}}
   port: 8080
+  # TODO: før vi overskriver ingress må konsumenter som kaller den få lagt til accessPolicy
+  #ingresses:
+  #  - https://altinn-rettigheter-proxy.intern.dev.nav.no/altinn-rettigheter-proxy
   liveness:
     path: /altinn-rettigheter-proxy/internal/alive
   readiness:

--- a/nais/prod-gcp.yaml
+++ b/nais/prod-gcp.yaml
@@ -15,6 +15,9 @@ spec:
     limits:
       cpu: 5000m # https://home.robusta.dev/blog/stop-using-cpu-limits/
       memory: 1024Mi
+  # TODO: før vi overskriver ingress må konsumenter som kaller den få lagt til accessPolicy
+  #ingresses:
+  #  - https://altinn-rettigheter-proxy.intern.nav.no/altinn-rettigheter-proxy/
   liveness:
     path: /altinn-rettigheter-proxy/internal/alive
   readiness:

--- a/nais/redis-dev-gcp.yaml
+++ b/nais/redis-dev-gcp.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: altinn-rettigheter-proxy-redis
     team: fager
-  name: redis-arbeidsgiver-altinnrettigheter
+  name: redis-fager-altinnrettigheter
   namespace: fager
 spec:
   plan: startup-4

--- a/nais/redis-dev-gcp.yaml
+++ b/nais/redis-dev-gcp.yaml
@@ -3,9 +3,9 @@ kind: Redis
 metadata:
   labels:
     app: altinn-rettigheter-proxy-redis
-    team: arbeidsgiver
+    team: fager
   name: redis-arbeidsgiver-altinnrettigheter
-  namespace: arbeidsgiver
+  namespace: fager
 spec:
   plan: startup-4
   project: nav-dev

--- a/nais/redis-prod-gcp.yaml
+++ b/nais/redis-prod-gcp.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: altinn-rettigheter-proxy-redis
     team: fager
-  name: redis-arbeidsgiver-altinnrettigheter
+  name: redis-fager-altinnrettigheter
   namespace: fager
 spec:
   plan: startup-4

--- a/src/main/kotlin/no/nav/arbeidsgiver/altinnrettigheter/proxy/maskinporten/MaskinportenTokenService.kt
+++ b/src/main/kotlin/no/nav/arbeidsgiver/altinnrettigheter/proxy/maskinporten/MaskinportenTokenService.kt
@@ -41,7 +41,7 @@ class MaskinportenTokenService(
         Thread {
             while (true) {
                 try {
-                    logger.info("sjekker om accesstoken er i ferd med å utløpe..")
+                    logger.debug("sjekker om accesstoken er i ferd med å utløpe..")
                     val token = tokenStore.get()
                     if (token == null || token.percentageRemaining() < 50.0) {
                         val newToken = maskinportenClient.fetchNewAccessToken()


### PR DESCRIPTION
Ting som må gjøres:
* oppdatere access policy og url i alle konsumenter
* lage ny ingress eller overskrive gamle
  * Ny ingress er tryggere, men mulig litt mere jobb
  * Må uansett oppdatere accesspolicy, så endre url er ikke veldig mye merarbeid
* Det er ikke stor jobb, men siden det er 11 konsumenter så blir det litt jobb likevel
  * Er ikke sikkert det bare er konfig, kan være nødvendig med oppdatere testkode feks
  
KAnskje dette ikke er verdt å gjøre siden appen skal fases ut etterhvert uansett?