### PR TITLE
Legge til access-policy for pia-sykefravarsstatistikk

### DIFF
--- a/nais/dev-gcp.yaml
+++ b/nais/dev-gcp.yaml
@@ -84,6 +84,9 @@ spec:
 
         - application: k9-inntektsmelding
           namespace: k9saksbehandling
+
+        - application: pia-sykefravarsstatistikk
+          namespace: pia
     outbound:
       external:
         - host: tt02.altinn.no


### PR DESCRIPTION
Team Pia migrerer on-prem `sykefravarsstatistikk-api` til `pia-sykefravarsstatistikk` i dev-gcp
Den nye applikasjonen trenger tilgang til `altinn-rettigheter-proxy` (dev-gcp i først omgang) 